### PR TITLE
fix: skip importing response types for binary endpoints

### DIFF
--- a/xdk-gen/templates/python/client_class.j2
+++ b/xdk-gen/templates/python/client_class.j2
@@ -25,10 +25,12 @@ from .models import (
     {% for operation in operations %}
     {% if operation.request_body %}
     {{ operation.class_name }}Request,
-    {% if operation.responses and "200" in operation.responses or operation.responses and "201" in operation.responses %}
-    {{ operation.class_name }}Response,
     {% endif %}
-    {% elif operation.responses and "200" in operation.responses or operation.responses and "201" in operation.responses %}
+    {# Only import response types for operations that return JSON (not binary) #}
+    {% set response_200 = operation.responses["200"] if operation.responses and "200" in operation.responses else none %}
+    {% set response_201 = operation.responses["201"] if operation.responses and "201" in operation.responses else none %}
+    {% set has_json_response = (response_200 and response_200.content and "application/json" in response_200.content) or (response_201 and response_201.content and "application/json" in response_201.content) %}
+    {% if has_json_response %}
     {{ operation.class_name }}Response,
     {% endif %}
     {% endfor %}

--- a/xdk-gen/templates/typescript/client_class.j2
+++ b/xdk-gen/templates/typescript/client_class.j2
@@ -16,10 +16,12 @@ import {
 {% for operation in operations -%}
 {% if operation.request_body -%}
     {{ operation.class_name }}Request,
-{% if operation.responses and "200" in operation.responses or operation.responses and "201" in operation.responses -%}
-    {{ operation.class_name }}Response,
 {% endif -%}
-{% elif operation.responses and "200" in operation.responses or operation.responses and "201" in operation.responses -%}
+{# Only import response types for operations that return JSON (not binary) #}
+{% set response_200 = operation.responses["200"] if operation.responses and "200" in operation.responses else none -%}
+{% set response_201 = operation.responses["201"] if operation.responses and "201" in operation.responses else none -%}
+{% set has_json_response = (response_200 and response_200.content and "application/json" in response_200.content) or (response_201 and response_201.content and "application/json" in response_201.content) -%}
+{% if has_json_response -%}
     {{ operation.class_name }}Response,
 {% endif -%}
 {% endfor -%}


### PR DESCRIPTION
## Problem

Operations that return `application/octet-stream` (binary data) like `chatMediaDownload` don't have response model classes generated in `models.j2`, since those templates only generate models for `application/json` responses.

However, the `client_class.j2` templates were importing response types for ALL operations with 200/201 responses, causing build errors like:

```
src/chat/client.ts(36,1): error TS2305: Module '"./models.js"' has no exported member 'MediaDownloadResponse'.
```

## Solution

Added a check in both TypeScript and Python `client_class.j2` templates to only import response types for operations that actually return JSON content, matching the behavior of the models templates.

Binary response operations correctly use `ArrayBuffer` (TypeScript) or `bytes` (Python) as return types and don't need imported response model types.

## Testing

- Rebuilt TypeScript SDK: ✅ builds successfully
- Rebuilt Python SDK: ✅ builds successfully