### PR TITLE
fix(typescript): clear timeout handle after fetch

### DIFF
--- a/xdk-gen/templates/typescript/http_client.j2
+++ b/xdk-gen/templates/typescript/http_client.j2
@@ -116,20 +116,28 @@ export class HttpClient {
 
     // Handle timeout
     let signal = options.signal;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
     if (options.timeout && options.timeout > 0 && !signal) {
       const controller = new AbortController();
-      setTimeout(() => controller.abort(), options.timeout);
+      timeoutId = setTimeout(() => controller.abort(), options.timeout);
       signal = controller.signal;
     }
 
-    const response = await this.fetch(url, {
-      method: options.method || 'GET',
-      headers: options.headers as any,
-      body: body as any,
-      signal: signal,
-    });
+    try {
+      const response = await this.fetch(url, {
+        method: options.method || 'GET',
+        headers: options.headers as any,
+        body: body as any,
+        signal: signal,
+      });
 
-    return response as HttpResponse;
+      return response as HttpResponse;
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes issue https://github.com/xdevplatform/xdk/issues/31

After this fix is applied, repro [script](https://gist.github.com/maxceem/7a7ac00633fd428e6061224a13036d78) outputs as expected:

```
> start
> node index.mjs

sending request...
response received after 450ms
{"data":{"id":"44196397","name":"Elon Musk","username":"elonmusk"}}
response is already received; if the process hangs, the SDK left something alive
beforeExit after 454ms
```