### PR TITLE
chore: bump SDK versions - Python v0.10.0, TypeScript v0.6.0

### DIFF
--- a/xdk-config.toml
+++ b/xdk-config.toml
@@ -3,7 +3,7 @@
 
 [versions]
 # Python SDK version
-python = "0.9.0"
+python = "0.10.0"
 
 # TypeScript SDK version
-typescript = "0.5.0"
+typescript = "0.6.0"


### PR DESCRIPTION
Minor version bump for both SDKs (fully-typed codegen release, #36).

Done via PR because the `Release SDK` workflow's direct push to main is now rejected by repository rules. After this merges, the release runs with `skip_publish=true` — it generates, tests, and pushes to the SDK repos, which auto-publish on the version change.

Note: `release.yml`'s prepare job needs updating to open a PR (or get ruleset bypass) for future releases.